### PR TITLE
Dockerfile: upgrading alpine to 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.6
 LABEL maintainer tgraf@tgraf.ch
 
 RUN \


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

Fixes DNS bugs

@tgraf I've tested this image with the minikube GSG. I had to temporally remove the `netperf` stuff since their server is currently down. We can merge it and hopefully it will be up in the next hours and Docker hub builds the image successfully. 

We should move https://hub.docker.com/r/cilium/demo-httpd/ to point to this repo as well